### PR TITLE
Consider only total costs of 2050 for carrier having share in generation mix

### DIFF
--- a/scripts/fill_main_data.py
+++ b/scripts/fill_main_data.py
@@ -39,6 +39,17 @@ def get_total_costs(network):
     df = df / 1e9
     df = df.groupby(df.index.map(rename_techs)).sum()
     df.drop("-", inplace=True)
+
+    # consider only carriers which have share in generation mix for 2050
+    if horizon == '2050':
+        # get generation mix and carriers with 0 generation mix
+        generation_mix = get_generation_mix(network)
+        non_generating_carriers = generation_mix[generation_mix == 0].index
+        non_generating_carriers = [s if s.isupper() else s.capitalize() for s in non_generating_carriers]
+
+        # drop carriers which have 0 generation
+        df.drop(index=non_generating_carriers, errors='ignore', inplace=True)
+
     return df
 
 

--- a/scripts/fill_main_data.py
+++ b/scripts/fill_main_data.py
@@ -34,7 +34,7 @@ def get_total_costs(network):
     total_costs = sum_costs(cap_costs, op_costs)
     
     df = total_costs.groupby(total_costs.index).sum()
-    
+
     # convert to billions
     df = df / 1e9
     df = df.groupby(df.index.map(rename_techs)).sum()
@@ -64,6 +64,17 @@ def get_investment_costs(network):
     df = df / 1e9
     df = df.groupby(df.index.map(rename_techs)).sum()
     df.drop("-", inplace=True)
+
+    # consider only carriers which have share in generation mix for 2050
+    if horizon == '2050':
+        # get generation mix and carriers with 0 generation mix
+        generation_mix = get_generation_mix(network)
+        non_generating_carriers = generation_mix[generation_mix == 0].index
+        non_generating_carriers = [s if s.isupper() else s.capitalize() for s in non_generating_carriers]
+
+        # drop carriers which have 0 generation
+        df.drop(index=non_generating_carriers, errors='ignore', inplace=True)
+
     return df
 
 
@@ -232,7 +243,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "fill_main_data", 
             countries="US",
-            planning_horizon="2021",
+            planning_horizon="2050",
         )
     # update config based on wildcards
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)


### PR DESCRIPTION
Good day. The PR proposes to account for the costs of carriers which have share in generation mix for 2050. For example, conventional carriers such as coal, OCGT, oil are phased out in 2050 to reach net-zero due to emission they introduce. Therefore, the capital costs of these plants should not be accounted in calculation of the total costs for 2050. The same approach needs to be done for investment costs. Because technologies that does not generate at all should not be considered in investment. The same goes for installed capacities.